### PR TITLE
fixes issue #2. added rule to flag for a warning when a double quote …

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ To view the rules in this ruleset you can use the following command.
 That gives us the following set.
 
 ```  
-   The Zicht standard contains 61 sniffs
+   The Zicht standard contains 62 sniffs
    
    Generic (13 sniffs)
    -------------------
@@ -168,7 +168,7 @@ That gives us the following set.
      PSR2.Namespaces.NamespaceDeclaration
      PSR2.Namespaces.UseDeclaration
    
-   Squiz (14 sniffs)
+   Squiz (15 sniffs)
    -----------------
      Squiz.Classes.ValidClassName
      Squiz.ControlStructures.ControlSignature
@@ -180,6 +180,7 @@ That gives us the following set.
      Squiz.Functions.LowercaseFunctionKeywords
      Squiz.Functions.MultiLineFunctionDeclaration
      Squiz.Scope.MethodScope
+     Squiz.Strings.DoubleQuoteUsage.NotRequired
      Squiz.WhiteSpace.ControlStructureSpacing
      Squiz.WhiteSpace.ScopeClosingBrace
      Squiz.WhiteSpace.ScopeKeywordSpacing

--- a/Zicht/incorrect.php
+++ b/Zicht/incorrect.php
@@ -34,3 +34,4 @@ class Invalid_name {
 }
 
 
+"invalid use of double quotes";

--- a/Zicht/ruleset.xml
+++ b/Zicht/ruleset.xml
@@ -77,6 +77,11 @@
         <severity>0</severity>
     </rule>
 
+    <rule ref="Squiz.Strings.DoubleQuoteUsage.NotRequired">
+        <severity>5</severity>
+        <type>warning</type>
+    </rule>
+
     <rule ref="Generic.Files.LineLength">
         <properties>
             <property name="lineLimit" value="120"/>


### PR DESCRIPTION
…is used in an unnecessary context