### PR TITLE
Exclude example files from classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
           "squizlabs/php_codesniffer": "^3"
      },
      "autoload": {
-          "classmap": ["Zicht"]
+          "classmap": ["Zicht"],
+          "exclude-from-classmap": ["/Zicht/correct.php", "/Zicht/incorrect.php"]
      }
 }


### PR DESCRIPTION
The files `Zicht/correct.php` and `Zicht/incorrect.php` are also being included in the classmap of the Composer autoloader:

```
    'A' => $vendorDir . '/zicht/standards-php/Zicht/incorrect.php',
    [...]
    'Zicht\\A' => $vendorDir . '/zicht/standards-php/Zicht/correct.php',
    'Zicht\\B' => $vendorDir . '/zicht/standards-php/Zicht/correct.php',
    'Zicht\\C' => $vendorDir . '/zicht/standards-php/Zicht/correct.php',
    'Zicht\\D' => $vendorDir . '/zicht/standards-php/Zicht/correct.php',
    [...]
    'invalidName' => $vendorDir . '/zicht/standards-php/Zicht/incorrect.php',
```

The suggested addition should exclude them