### PR TITLE
Allow declare statement in use statement check

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ code like `$sniff = new NamespaceSniff()`;
 
 #### Zicht.PHP.UseStatement
 This sniff defines that the use statements should be at the top of in a PHP file and can only be preceded by 
-doc blocks or the namespace declaration (and surely whitespaces etc).
+a declare statement, doc blocks or the namespace declaration (and surely whitespaces etc).
 
 #### Zicht.Whitespace.ExcessiveWhitespace
 This sniff looks for more then one whitespace after the last `}` in a file. 

--- a/Zicht/Sniffs/PHP/UseStatementSniff.php
+++ b/Zicht/Sniffs/PHP/UseStatementSniff.php
@@ -95,6 +95,8 @@ class UseStatementSniff implements Sniff
                 $tokens[ $ptr ]['code'],
                 [
                     T_OPEN_TAG,
+                    T_DECLARE,
+                    T_LNUMBER,
                     T_NAMESPACE,
                     T_COMMENT,
                     T_DOC_COMMENT,


### PR DESCRIPTION
In a project the linter give me a warning:

```
   9 | WARNING | Use statement on any other position than top of file
     |         | is discouraged.
     |         | (Zicht.PHP.UseStatement.TopOfFile)
```

Because of the following code:

```
<?php
declare(strict_types=1);
/**
 * @copyright Zicht Online <http://zicht.nl>
 */

namespace Zicht\xxx\yyy\Command;

use Symfony\Component\Console\Command\Command;
```

The check for use statements doesn't allow `declare()` statements. I analysed the tokens of declare statements and concluded that `T_DECLARE` and `T_LNUMBER` should be added if we want to allow this:

```
declare => T_DECLARE
(
strict_types => T_STRING
=
1 => T_LNUMBER
)
```
