### PR TITLE
[ZICHTDEV] Disallow @author and @package tags in class and file comments

### DIFF
--- a/Zicht/Sniffs/Commenting/ClassCommentSniff.php
+++ b/Zicht/Sniffs/Commenting/ClassCommentSniff.php
@@ -1,54 +1,53 @@
 <?php
 /**
- * @author Gerard van Helden <gerard@zicht.nl>
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Sniffs\Commenting;
 
-use PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\ClassCommentSniff as PEARClassCommentSniff;
+use PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\ClassCommentSniff as PearClassCommentSniff;
 
 /**
  * Sniffs the doc comment tags in class level comments
  */
-class ClassCommentSniff extends PEARClassCommentSniff
+class ClassCommentSniff extends PearClassCommentSniff
 {
+    use DisallowTagsTrait;
+
     protected $tags = [
-        'author' => [
-            'required' => false,
-            'allow_multiple' => true,
-            'order_text' => 'precedes @copyright',
+        '@category' => [
+            'disallow' => true,
         ],
-        'copyright' => [
-            'required' => false,
-            'allow_multiple' => true,
-            'order_text' => 'follows @author',
+        '@package' => [
+            'disallow' => true,
         ],
-        'version' => [
+        '@subpackage' => [
+            'disallow' => true,
+        ],
+        '@author' => [
+            'disallow' => true,
+        ],
+        '@copyright' => [
+            'disallow' => true,
+        ],
+        '@version' => [
             'required' => false,
             'allow_multiple' => false,
             'order_text' => 'follows @license',
         ],
-        'see' => [
+        '@link' => [
+            'required' => false,
+            'allow_multiple' => true,
+        ],
+        '@see' => [
             'required' => false,
             'allow_multiple' => true,
             'order_text' => 'follows @link',
         ],
-        'deprecated' => [
+        '@deprecated' => [
             'required' => false,
             'allow_multiple' => false,
             'order_text' => 'follows @see (if used) or @version (if used) or @copyright (if used)',
         ],
     ];
-
-    /**
-     * Override to skip the file comments
-     *
-     * @param int $commentStart
-     * @return void
-     */
-    protected function processCopyrights($commentStart)
-    {
-        // skip copyrights semantics.
-    }
 }

--- a/Zicht/Sniffs/Commenting/ClassConstantCommentSniff.php
+++ b/Zicht/Sniffs/Commenting/ClassConstantCommentSniff.php
@@ -1,6 +1,5 @@
 <?php
 /**
- * @author Gerard van Helden <gerard@zicht.nl>
  * @copyright Zicht Online <http://zicht.nl>
  */
 

--- a/Zicht/Sniffs/Commenting/DefineCommentSniff.php
+++ b/Zicht/Sniffs/Commenting/DefineCommentSniff.php
@@ -1,6 +1,5 @@
 <?php
 /**
- * @author Gerard van Helden <gerard@zicht.nl>
  * @copyright Zicht Online <http://zicht.nl>
  */
 

--- a/Zicht/Sniffs/Commenting/DisallowTagsTrait.php
+++ b/Zicht/Sniffs/Commenting/DisallowTagsTrait.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @copyright Zicht Online <https://www.zicht.nl>
+ */
+
+namespace Zicht\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\ClassCommentSniff as PearClassCommentSniff;
+use PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\FileCommentSniff as PearFileCommentSniff;
+
+trait DisallowTagsTrait
+{
+    /**
+     * Processes disallowed tags, after that, follow normal process for other tags
+     *
+     * @param File $phpcsFile    The file being scanned.
+     * @param int $stackPtr      The position of the current token in the stack passed in $tokens.
+     * @param int $commentStart  Position in the stack where the comment started.
+     * @see PearFileCommentSniff::processTags()
+     */
+    protected function processTags($phpcsFile, $stackPtr, $commentStart)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $docBlock = $this instanceof PearClassCommentSniff ? 'class' : 'file';
+
+        foreach ($tokens[$commentStart]['comment_tags'] as $tagPos) {
+            $name = $tokens[$tagPos]['content'];
+            if (!isset($this->tags[$name])) {
+                continue;
+            }
+            if (isset($this->tags[$name]['disallow']) && true === $this->tags[$name]['disallow']) {
+                $error = 'Tag %s is not allowed in %s comment';
+                $data = [$name, $docBlock];
+                $code = sprintf('NotAllowed%sTag', ucfirst(substr($name, 1)));
+                $fix = $phpcsFile->addFixableError($error, $tagPos, $code, $data);
+                if ($fix) {
+                    $linePos = $tagPos;
+                    while ($linePos > $commentStart && $tokens[$linePos]['line'] === $tokens[$tagPos]['line']) {
+                        $linePos--;
+                    }
+                    $linePos++;
+                    $commentEnd = $tokens[$commentStart]['comment_closer'];
+                    do {
+                        $phpcsFile->fixer->replaceToken($linePos, '');
+                    } while ($tokens[++$linePos]['line'] === $tokens[$tagPos]['line'] && $linePos !== $commentEnd);
+                }
+            }
+        }
+
+        // Only process other tags that not contain `disallow`
+        $originalTags = $this->tags;
+        $this->tags = array_filter(
+            $this->tags,
+            function ($opts) {
+                return !isset($opts['disallow']) || true !== $opts['disallow'];
+            }
+        );
+
+        parent::processTags($phpcsFile, $stackPtr, $commentStart);
+
+        $this->tags = $originalTags;
+    }
+}

--- a/Zicht/Sniffs/Commenting/FileCommentSniff.php
+++ b/Zicht/Sniffs/Commenting/FileCommentSniff.php
@@ -1,43 +1,69 @@
 <?php
 /**
- * @author Gerard van Helden <gerard@zicht.nl>
  * @copyright Zicht Online <http://zicht.nl>
  */
 
 namespace Zicht\Sniffs\Commenting;
 
-use PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\FileCommentSniff as PEARFileCommentSniff;
+use PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\FileCommentSniff as PearFileCommentSniff;
 
 /**
  * Sniffs the doc comment tags in a file comment
  */
-class FileCommentSniff extends PEARFileCommentSniff
+class FileCommentSniff extends PearFileCommentSniff
 {
+    use DisallowTagsTrait;
+
     protected $tags = [
-        'author' => [
-            'required' => false,
-            'allow_multiple' => true,
-            'order_text' => 'precedes @copyright',
+        '@category' => [
+            'disallow' => true,
         ],
-        'copyright' => [
-            'required' => false,
-            'allow_multiple' => true,
-            'order_text' => 'follows @author',
+        '@package' => [
+            'disallow' => true,
         ],
-        'version' => [
+        '@subpackage' => [
+            'disallow' => true,
+        ],
+        '@author' => [
+            'disallow' => true,
+        ],
+        '@copyright' => [
+            'required' => false,
+            'allow_multiple' => true
+        ],
+        '@version' => [
             'required' => false,
             'allow_multiple' => false,
             'order_text' => 'follows @license',
         ],
-        'see' => [
+        '@link' => [
+            'required' => false,
+            'allow_multiple' => true,
+        ],
+        '@see' => [
             'required' => false,
             'allow_multiple' => true,
             'order_text' => 'follows @link',
         ],
-        'deprecated' => [
+        '@deprecated' => [
             'required' => false,
             'allow_multiple' => false,
             'order_text' => 'follows @see (if used) or @version (if used) or @copyright (if used)',
         ],
     ];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function processCopyright($phpcsFile, array $tags)
+    {
+        /**
+         * No further processing, skipping rules:
+         * - Zicht.Commenting.FileComment.IncompleteCopyright
+         * - Zicht.Commenting.FileComment.InvalidCopyright
+         * - Zicht.Commenting.FileComment.CopyrightHyphen
+         * @see PearFileCommentSniff::processCopyright()
+         */
+        return;
+    }
 }

--- a/Zicht/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/Zicht/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -1,6 +1,5 @@
 <?php
 /**
- * @author Gerard van Helden <gerard@zicht.nl>
  * @copyright Zicht Online <http://zicht.nl>
  */
 

--- a/Zicht/Sniffs/NamingConventions/ClassnameSniff.php
+++ b/Zicht/Sniffs/NamingConventions/ClassnameSniff.php
@@ -1,6 +1,5 @@
 <?php
 /**
- * @author Gerard van Helden <gerard@zicht.nl>
  * @copyright Zicht Online <http://zicht.nl>
  */
 

--- a/Zicht/Sniffs/NamingConventions/ConstantsSniff.php
+++ b/Zicht/Sniffs/NamingConventions/ConstantsSniff.php
@@ -1,6 +1,5 @@
 <?php
 /**
- * @author Gerard van Helden <gerard@zicht.nl>
  * @copyright Zicht Online <http://zicht.nl>
  */
 

--- a/Zicht/Sniffs/NamingConventions/FunctionsSniff.php
+++ b/Zicht/Sniffs/NamingConventions/FunctionsSniff.php
@@ -1,6 +1,5 @@
 <?php
 /**
- * @author Gerard van Helden <gerard@zicht.nl>
  * @copyright Zicht Online <http://zicht.nl>
  */
 

--- a/Zicht/Sniffs/PHP/NamespaceSniff.php
+++ b/Zicht/Sniffs/PHP/NamespaceSniff.php
@@ -1,6 +1,5 @@
 <?php
 /**
- * @author Gerard van Helden <gerard@zicht.nl>
  * @copyright Zicht Online <http://zicht.nl>
  */
 

--- a/Zicht/Sniffs/PHP/UseStatementSniff.php
+++ b/Zicht/Sniffs/PHP/UseStatementSniff.php
@@ -1,6 +1,5 @@
 <?php
 /**
- * @author Gerard van Helden <gerard@zicht.nl>
  * @copyright Zicht Online <http://zicht.nl>
  */
 

--- a/Zicht/Sniffs/Whitespace/ExcessiveWhitespaceSniff.php
+++ b/Zicht/Sniffs/Whitespace/ExcessiveWhitespaceSniff.php
@@ -1,6 +1,5 @@
 <?php
 /**
- * @author Gerard van Helden <gerard@zicht.nl>
  * @copyright Zicht Online <http://zicht.nl>
  */
 

--- a/Zicht/ruleset.xml
+++ b/Zicht/ruleset.xml
@@ -36,6 +36,7 @@
     <rule ref="Generic.Formatting.SpaceAfterCast.NoSpace">
         <severity>0</severity>
     </rule>
+
     <rule ref="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma">
      <severity>0</severity>
     </rule>
@@ -68,18 +69,24 @@
     <rule ref="Zicht.Commenting.FileComment.TagIndent">
         <severity>0</severity>
     </rule>
-    <rule ref="Zicht.Commenting.ClassComment.TagIndent">
-        <severity>0</severity>
-    </rule>
     <rule ref="Zicht.Commenting.FileComment.SpacingBeforeTags">
         <severity>0</severity>
     </rule>
+
+    <rule ref="Zicht.Commenting.ClassComment.Missing">
+        <severity>0</severity>
+    </rule>
+    <rule ref="Zicht.Commenting.ClassComment.EmptyCopyright">
+        <severity>0</severity>
+    </rule>
+    <rule ref="Zicht.Commenting.ClassComment.TagIndent">
+        <severity>0</severity>
+    </rule>
+
     <rule ref="PEAR.ControlStructures.ControlSignature">
         <severity>0</severity>
     </rule>
-    <rule ref="PEAR.Commenting.ClassComment.EmptyCopyright">
-        <severity>0</severity>
-    </rule>
+
     <rule ref="Generic.Functions.OpeningFunctionBraceBsdAllman.BraceOnSameLine">
         <severity>0</severity>
     </rule>
@@ -95,7 +102,11 @@
             <property name="absoluteLineLimit" value="130"/>
         </properties>
     </rule>
+
     <rule ref="PEAR.Classes.ClassDeclaration.OpenBraceNewLine" />
+
     <rule ref="PSR1" />
+
     <rule ref="PSR2" />
+
 </ruleset>


### PR DESCRIPTION
Resolves #10 #9 

Additionally disallows `@category` and `@subpackage` tags.
Additionally disallows `@copyright` in class comments

Also adds allowing to skip the class comment.