### PR TITLE
[ZICHTDEV] Do not allow empty or superfluous docblocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,25 @@ standard applies some custom rules and modifications to these standards:
 
 ## Usage 
 
-```
+```bash
 composer require --dev zicht/standards-php
 ```
 
-Run `./vendor/bin/phpcs -s src/Zicht/ tests/Zicht/ --standard=vendor/zicht/standards-php/Zicht --extensions=php`
+Run `vendor/bin/phpcs -s --standard=vendor/zicht/standards-php/Zicht --extensions=php <directories-and-files>`
 
-Also you could incorporate the check in the `scripts` section of composer like this.
-```
-"lint": [
-    "phpcs -s src/Zicht/ tests/Zicht/ --standard=vendor/zicht/standards-php/Zicht --extensions=php"
-]
+Also you could incorporate the check in the `scripts` section of composer like this and also add a fix command:
+```json
+{
+    "scripts": {
+        "lint": [
+            "phpcs -s --standard=vendor/zicht/standards-php/Zicht --extensions=php src/Zicht/ tests/Zicht/"
+        ],
+        "lint-fix": [
+            "phpcbf -s --standard=vendor/zicht/standards-php/Zicht --extensions=php src/Zicht/ tests/Zicht/"
+        ]
+    }
+}
+
 ```
 
 ## Current ruleset
@@ -34,8 +42,45 @@ Also you could incorporate the check in the `scripts` section of composer like t
 ### Zicht Sniffs
 In this section each of the rules from the Zicht set are explained.
 
+#### Commenting in general
+All doc block comment sniffs (ClassComment, FileComment and FunctionComment) will scan for empty doc blocks and doc blocks
+containing superfluous descriptions. Empty doc blocks and doc block containing only a superfluous comment (no tags) must
+be improved or removed. The description of doc blocks having a superfluous description and having tags must be improved
+or removed.
+
+Superfluous descriptions are detected by looking at the declaration the doc block belongs to and see if it is a repetition
+of its name, which obviously is not adding anything of value. Superfluous doc blocks/descriptions are auto-fixable.
+Example, all three doc block comments produce an error by the related sniff because the descriptions are superfluous:
+```php
+<?php
+/**
+ * Class SomeExampleClass                   <-- Doc block must be improved or removed
+ */
+class SomeExampleClass
+{
+    /**
+     * SomeClass constructor.               <-- Doc block must be improved or removed
+     */
+    public function __construct()
+    {
+        $this->setSomeValues([1, 2, 3]);
+    }
+
+    /**
+     * Set some values                      <-- Description must be improved or removed
+     *
+     * @param int[] $someValues  Integer values to set
+     */
+    public function setSomeValues(array $someValues)
+    {
+        $this->someValues = $someValues;
+    }
+}
+```
+
 #### Zicht.Commenting.ClassComment
-Extends `PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\ClassCommentSniff` and adds rules about what the doc block could 
+Extends `PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\ClassCommentSniff`. Additionally detects empty or superfluous
+comments (see _[Commenting in general](#commenting-in-general)_) and adds rules about what the doc block is allowed to
 contain in a class doc comment.
 
 - `@category`, `@package`, `@subpackage`, `@author` and `@copyright` tags are not allowed in class doc comments.
@@ -51,7 +96,8 @@ Requires constants in classes to have a doc block.
 Looks for comments before the `define` function of PHP.
 
 #### Zicht.Commenting.FileComment
-Extends `PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\FileCommentSniff` and adds rules about what the doc block could 
+Extends `PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\FileCommentSniff`. Additionally detects empty or superfluous
+comments (see _[Commenting in general](#commenting-in-general)_) and adds rules about what the doc block is allowed to
 contain in a file doc comment.
 
 - `@category`, `@package`, `@subpackage` and `@author` tags are not allowed in file doc comments.
@@ -63,11 +109,12 @@ contain in a file doc comment.
 `@copyright` (if used).
 
 #### Zicht.Commenting.FunctionComment
-Extends `\PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\FunctionCommentSniff` to allow `{@inheritdoc}` in the 
-function comment which makes it skip params and return tags validation (if no `@param` or `@return` is added additionally).
+Extends `\PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\FunctionCommentSniff`. Additionally detects empty or
+superfluous comments (see _[Commenting in general](#commenting-in-general)_) and detects `{@inheritdoc}` in the function
+comment which makes it skip params and return tags validation (if no `@param` or `@return` is added additionally).
 Also this sniff allows skipping a function comment when there are no parameters and returned values or when all parameters
 and the returned value have their type declared (type _hinted_):
-```
+```php
 public function getMeSomeArray(int $id, SomeObject $someObject = null): array
 {
     return [];
@@ -127,13 +174,13 @@ a declare statement, doc blocks or the namespace declaration (and surely whitesp
 This sniff looks for more then one whitespace after the last `}` in a file. 
 
 ### Other rules
-To view the rules in this ruleset you can use the following command.
+To view the rules in this ruleset you can use the following command from the package root:
+```bash
+vendor/bin/phpcs --standard=Zicht -e
 ```
-./vendor/bin/phpcs --standard=Zicht -e
-```
-That gives us the following set.
+That will produce the following set:
 
-```  
+```text
    The Zicht standard contains 63 sniffs
    
    Generic (14 sniffs)

--- a/Zicht/PhpCsFile.php
+++ b/Zicht/PhpCsFile.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * @copyright Zicht Online <https://www.zicht.nl>
+ */
+
+namespace Zicht;
+
+use PHP_CodeSniffer\Files\File;
+
+class PhpCsFile
+{
+    /**
+     * @param File $phpcsFile
+     * @param int $stackPtr
+     * @param array<string,int> $limit  Optional start and end positions, exclusive
+     * @return array
+     */
+    public static function getLineTokens(File $phpcsFile, $stackPtr, array $limit = [])
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $lineTokens = [];
+
+        static::walkLine(
+            function ($pos, $token) use (&$lineTokens) {
+                $lineTokens[$pos] = $token;
+            },
+            $tokens,
+            $stackPtr,
+            $limit
+        );
+
+        return $lineTokens;
+    }
+
+    /**
+     * Returns the position of the first token of the previous line
+     *
+     * @param File $phpcsFile
+     * @param int $stackPtr
+     * @return int|null
+     */
+    public static function getPreviousLine(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $linePos = $stackPtr;
+        while (isset($tokens[$linePos - 1]) && $tokens[$linePos - 1]['line'] >= $tokens[$stackPtr]['line'] - 1) {
+            $linePos--;
+        }
+
+        if ($tokens[$linePos]['line'] !== $tokens[$stackPtr]['line'] - 1) {
+            return null;
+        }
+
+        return $linePos;
+    }
+
+    /**
+     * Returns the position of the first token of the next line
+     *
+     * @param File $phpcsFile
+     * @param int $stackPtr
+     * @return int|null
+     */
+    public static function getNextLine(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $linePos = $stackPtr;
+        while (isset($tokens[$linePos + 1]) && $tokens[$linePos]['line'] === $tokens[$stackPtr]['line']) {
+            $linePos++;
+        }
+
+        if ($tokens[$linePos]['line'] !== $tokens[$stackPtr]['line'] + 1) {
+            return null;
+        }
+
+        return $linePos;
+    }
+
+    /**
+     * @param File $phpcsFile
+     * @param int $stackPtr
+     * @param array<string,int> $limit  Optional start and end positions, exclusive
+     * @return string|null
+     */
+    public static function getLineContents(File $phpcsFile, $stackPtr, array $limit = [])
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $lineContents = null;
+
+        static::walkLine(
+            function ($pos, $token) use (&$tokenCodes, &$lineContents) {
+                $lineContents .= (string)$token['content'];
+            },
+            $tokens,
+            $stackPtr,
+            $limit
+        );
+
+        return $lineContents;
+    }
+
+    /**
+     * @param File $phpcsFile
+     * @param int $stackPtr
+     * @param array $tokenCodes
+     * @param array<string,int> $limit  Optional start and end positions, exclusive
+     * @return int|null
+     */
+    public static function lineContainsTokens(File $phpcsFile, $stackPtr, array $tokenCodes, array $limit = [])
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $lineContainsTokens = null;
+
+        static::walkLine(
+            function ($pos, $token) use (&$tokenCodes, &$lineContainsTokens) {
+                if (in_array($token['code'], $tokenCodes, true)) {
+                    $lineContainsTokens = $pos;
+                }
+            },
+            $tokens,
+            $stackPtr,
+            $limit
+        );
+
+        return $lineContainsTokens;
+    }
+
+    /**
+     * @param File $phpcsFile
+     * @param int $stackPtr
+     * @param array<string,int> $limit  Optional start and end positions, exclusive
+     */
+    public static function fixRemoveWholeLine(File $phpcsFile, $stackPtr, array $limit = [])
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        static::walkLine(
+            function ($pos, $token) use ($phpcsFile) {
+                $phpcsFile->fixer->replaceToken($pos, '');
+            },
+            $tokens,
+            $stackPtr,
+            $limit
+        );
+    }
+
+    /**
+     * @param callable $callback
+     * @param array $tokens
+     * @param int $stackPtr
+     * @param array<string,int> $limit  Optional start and end positions, exclusive
+     */
+    private static function walkLine(callable $callback, array &$tokens, $stackPtr, array $limit = [])
+    {
+        $limit = array_merge(['start' => null, 'end' => null], $limit);
+
+        $linePos = $stackPtr;
+        while (isset($tokens[$linePos - 1]) && $tokens[$linePos - 1]['line'] === $tokens[$stackPtr]['line']
+            && (null === $limit['start'] || $linePos - 1 > $limit['start'])) {
+            $linePos--;
+        }
+
+        do {
+            if ((null === $limit['start'] || $linePos > $limit['start'])
+                && (null === $limit['end'] || $linePos < $limit['end'])) {
+                $callback($linePos, $tokens[$linePos]);
+            }
+        } while ($tokens[++$linePos]['line'] === $tokens[$stackPtr]['line']
+        && (null === $limit['end'] || $linePos < $limit['end']));
+    }
+}

--- a/Zicht/Sniffs/Commenting/ClassCommentSniff.php
+++ b/Zicht/Sniffs/Commenting/ClassCommentSniff.php
@@ -8,11 +8,12 @@ namespace Zicht\Sniffs\Commenting;
 use PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\ClassCommentSniff as PearClassCommentSniff;
 
 /**
- * Sniffs the doc comment tags in class level comments
+ * Checks for empty or superfluous class doc comments, sniffs the doc comment tags in class level comments
  */
 class ClassCommentSniff extends PearClassCommentSniff
 {
-    use DisallowTagsTrait;
+    use DisallowTagsTrait,
+        EmptyCommentTrait;
 
     protected $tags = [
         '@category' => [
@@ -47,7 +48,16 @@ class ClassCommentSniff extends PearClassCommentSniff
         '@deprecated' => [
             'required' => false,
             'allow_multiple' => false,
-            'order_text' => 'follows @see (if used) or @version (if used) or @copyright (if used)',
+            'order_text' => 'follows @see (if used) or @version (if used)',
         ],
     ];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function processTags($phpcsFile, $stackPtr, $commentStart)
+    {
+        $this->processIsEmptyDocBlock($phpcsFile, $stackPtr, $commentStart);
+        $this->processDisallowedTags($phpcsFile, $stackPtr, $commentStart);
+    }
 }

--- a/Zicht/Sniffs/Commenting/EmptyCommentTrait.php
+++ b/Zicht/Sniffs/Commenting/EmptyCommentTrait.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * @copyright Zicht Online <https://www.zicht.nl>
+ */
+
+namespace Zicht\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Files\File;
+use Zicht\PhpCsFile as ZichtPhpCs_File;
+
+trait EmptyCommentTrait
+{
+    /**
+     * Check if doc block is empty or superfluous
+     *
+     * @param File $phpcsFile
+     * @param int $stackPtr
+     * @param int|null $commentStart
+     * @return bool
+     */
+    protected function processIsEmptyDocBlock(File $phpcsFile, $stackPtr, $commentStart)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $commentEnd = $tokens[$commentStart]['comment_closer'];
+        $docBlockEmpty = true;
+        $docBlockStrings = [];
+
+        if ($commentStart + 1 !== $commentEnd) {
+            for ($pos = $commentStart + 1; $pos < $commentEnd; $pos++) {
+                if (!in_array($tokens[$pos]['code'], [T_DOC_COMMENT_WHITESPACE, T_DOC_COMMENT_STAR])) {
+                    $docBlockEmpty = false;
+                    if (T_DOC_COMMENT_STRING === $tokens[$pos]['code']) {
+                        $docBlockStrings[$pos] = $tokens[$pos]['content'];
+                    } elseif (T_DOC_COMMENT_TAG === $tokens[$pos]['code']) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        $fixRemoveWhole = $fixRemoveLinePos = false;
+        try {
+            $declarationName = $phpcsFile->getDeclarationName($stackPtr);
+            $type = strtolower($tokens[$stackPtr]['content']);
+        } catch (RuntimeException $e) {
+            $declarationName = basename($phpcsFile->getFilename());
+            $type = 'file';
+        }
+
+        if ($docBlockEmpty) {
+            $fixRemoveWhole = $phpcsFile->addFixableError(
+                'Doc comment for %s %s%s is empty and must be removed',
+                $commentEnd,
+                'Empty',
+                [$type, $declarationName, ('function' === $type ? '()' : '')]
+            );
+        } elseif (0 < count($docBlockStrings)) {
+            /**
+             * - Filtering out everything that is not an `a-z` character leaves an empty comment: so superfluous
+             * - Filtered comment is exactly the same as filtered function name: comment doesn't add anything => superfluous
+             * - Comment is the same as type + name: "Function/Method Bla Bla Xyz" ~ "blaBlyXyz()" => superfluous
+             */
+            $filteredDocBlockString = preg_replace('/[^a-z]/', '', strtolower(implode('', $docBlockStrings)));
+            $superfluousReplacements = [
+                preg_replace('/[^a-z]/', '', strtolower($declarationName)),
+                $type,
+            ];
+            if ('function' === $type) {
+                $superfluousReplacements[] = 'method';
+                if ('__' === substr($declarationName, 0, 2)) {
+                    $superfluousReplacements[] = 'magic';
+                }
+            }
+            if (isset($tokens[$stackPtr]['conditions']) && 0 < count($tokens[$stackPtr]['conditions'])) {
+                $parentPos = key($tokens[$stackPtr]['conditions']);
+                try {
+                    $superfluousReplacements[] = preg_replace('/[^a-z]/', '', strtolower($phpcsFile->getDeclarationName($parentPos)));
+                    $superfluousReplacements[] = $tokens[$parentPos]['content'];
+                } catch (RuntimeException $e) {
+                    // Ignore if the declaration name of the parent cannot be found
+                }
+            }
+
+            if (3 >= strlen($filteredDocBlockString) || 3 >= strlen(str_replace($superfluousReplacements, '', $filteredDocBlockString))) {
+                $code = 'Superfluous';
+                $errorPos = key($docBlockStrings);
+                $errorMssgData = [implode(' ', $docBlockStrings), $type, $declarationName, ('function' === $type ? '()' : '')];
+                if (!isset($tokens[$commentStart]['comment_tags']) || 0 === count($tokens[$commentStart]['comment_tags'])) {
+                    $errorMssg = 'Doc comment "%s" for %s %s%s is superfluous and must be improved or removed';
+                    $fixRemoveWhole = $phpcsFile->addFixableError($errorMssg, $errorPos, $code, $errorMssgData);
+                } else {
+                    $errorMssg = 'Doc comment description "%s" for %s %s%s is superfluous and must be improved or removed';
+                    $fixRemoveLinePos = ($phpcsFile->addFixableError($errorMssg, $errorPos, $code, $errorMssgData) ? $errorPos : false);
+                }
+            }
+        }
+
+        if ($fixRemoveWhole) {
+            // Clear the whole doc block including preceding and succeeding white space
+            $linePos = $commentStart - 1;
+            while ($tokens[$linePos]['line'] === $tokens[$commentStart]['line'] && T_WHITESPACE === $tokens[$linePos]['code']) {
+                $linePos--;
+            }
+            $linePos++;
+            do {
+                $phpcsFile->fixer->replaceToken($linePos, '');
+            } while ($tokens[++$linePos]['line'] <= $tokens[$commentEnd]['line']
+                && ($linePos <= $commentEnd || T_WHITESPACE === $tokens[$linePos]['code']));
+        } elseif (false !== $fixRemoveLinePos) {
+            $commentEnd = $tokens[$commentStart]['comment_closer'];
+            ZichtPhpCs_File::fixRemoveWholeLine($phpcsFile, $fixRemoveLinePos, ['start' => $commentStart, 'end' => $commentEnd]);
+            while (null !== ($nextLinePos = ZichtPhpCs_File::getNextLine($phpcsFile, (isset($nextLinePos) ? $nextLinePos : $fixRemoveLinePos)))
+                && '' === trim(ZichtPhpCs_File::getLineContents($phpcsFile, $nextLinePos), " *\r\n")
+                || !ZichtPhpCs_File::lineContainsTokens($phpcsFile, $nextLinePos, [T_DOC_COMMENT_CLOSE_TAG, T_DOC_COMMENT_TAG])) {
+                ZichtPhpCs_File::fixRemoveWholeLine($phpcsFile, $nextLinePos);
+            }
+        }
+
+        return $docBlockEmpty;
+    }
+}

--- a/Zicht/Sniffs/Commenting/FileCommentSniff.php
+++ b/Zicht/Sniffs/Commenting/FileCommentSniff.php
@@ -8,11 +8,12 @@ namespace Zicht\Sniffs\Commenting;
 use PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\FileCommentSniff as PearFileCommentSniff;
 
 /**
- * Sniffs the doc comment tags in a file comment
+ * Checks for empty or superfluous file doc comments, sniffs the doc comment tags in a file comment
  */
 class FileCommentSniff extends PearFileCommentSniff
 {
-    use DisallowTagsTrait;
+    use DisallowTagsTrait,
+        EmptyCommentTrait;
 
     protected $tags = [
         '@category' => [
@@ -51,6 +52,15 @@ class FileCommentSniff extends PearFileCommentSniff
             'order_text' => 'follows @see (if used) or @version (if used) or @copyright (if used)',
         ],
     ];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function processTags($phpcsFile, $stackPtr, $commentStart)
+    {
+        $this->processIsEmptyDocBlock($phpcsFile, $stackPtr, $commentStart);
+        $this->processDisallowedTags($phpcsFile, $stackPtr, $commentStart);
+    }
 
     /**
      * {@inheritdoc}

--- a/Zicht/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Zicht/Sniffs/Commenting/FunctionCommentSniff.php
@@ -15,6 +15,8 @@ use PHP_CodeSniffer\Util\Tokens;
  */
 class FunctionCommentSniff extends PearFunctionCommentSniff implements Sniff
 {
+    use EmptyCommentTrait;
+
     /** @var bool */
     protected $paramsNeedProcessing;
 
@@ -49,6 +51,7 @@ class FunctionCommentSniff extends PearFunctionCommentSniff implements Sniff
 
         $hasDocComment = T_DOC_COMMENT_CLOSE_TAG === $tokens[$commentEnd]['code'];
         $commentStart = ($hasDocComment ? $tokens[$commentEnd]['comment_opener'] : null);
+
         $inheritDoc = $hasDocComment && $this->processInheritDoc($phpcsFile, $commentStart);
         $hasParamDefined = $hasDocComment && $this->hasCommentTag($phpcsFile, $commentStart, '@param');
         $hasReturnDefined = $hasDocComment && $this->hasCommentTag($phpcsFile, $commentStart, '@return');
@@ -59,6 +62,9 @@ class FunctionCommentSniff extends PearFunctionCommentSniff implements Sniff
         $this->returnNeedsProcessing = $hasReturnDefined
             || !$inheritDoc && $this->doesReturnSomething($phpcsFile, $stackPtr) && !$this->hasReturnTypeDeclared($phpcsFile, $stackPtr);
 
+        if ($hasDocComment) {
+            $this->processIsEmptyDocBlock($phpcsFile, $stackPtr, $commentStart);
+        }
         if ($hasDocComment || $this->paramsNeedProcessing || $this->returnNeedsProcessing) {
             parent::process($phpcsFile, $stackPtr);
         }

--- a/Zicht/Sniffs/PHP/NamespaceSniff.php
+++ b/Zicht/Sniffs/PHP/NamespaceSniff.php
@@ -8,9 +8,6 @@ namespace Zicht\Sniffs\PHP;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-/**
- * Class NamespaceSniff
- */
 class NamespaceSniff implements Sniff
 {
     /**

--- a/Zicht/Sniffs/PHP/UseStatementSniff.php
+++ b/Zicht/Sniffs/PHP/UseStatementSniff.php
@@ -9,9 +9,6 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 
-/**
- * Sniffs for
- */
 class UseStatementSniff implements Sniff
 {
     /**

--- a/Zicht/Sniffs/Whitespace/ExcessiveWhitespaceSniff.php
+++ b/Zicht/Sniffs/Whitespace/ExcessiveWhitespaceSniff.php
@@ -8,9 +8,6 @@ namespace Zicht\Sniffs\Whitespace;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-/**
- * A sniff that checks for excessive whitespace lines.
- */
 class ExcessiveWhitespaceSniff implements Sniff
 {
     /**


### PR DESCRIPTION
In addition to allowing to leave out a doc block...

See [added README section](https://github.com/zicht/standards-php/blob/14094f5fa5a18bbabc0dfdd1dab0b61b2be390c2/README.md#commenting-in-general) for a description