### PR TITLE
Disallow space between function opening brace and it's body

### DIFF
--- a/Zicht/Sniffs/Commenting/DisallowTagsTrait.php
+++ b/Zicht/Sniffs/Commenting/DisallowTagsTrait.php
@@ -37,6 +37,7 @@ trait DisallowTagsTrait
                 $code = sprintf('NotAllowed%sTag', ucfirst(substr($name, 1)));
                 $fix = $phpcsFile->addFixableError($error, $tagPos, $code, $data);
                 if ($fix) {
+                    $phpcsFile->fixer->beginChangeset();
                     $commentEnd = $tokens[$commentStart]['comment_closer'];
                     ZichtPhpCs_File::fixRemoveWholeLine($phpcsFile, $tagPos, ['start' => $commentStart, 'end' => $commentEnd]);
                     while (null !== ($nextLinePos = ZichtPhpCs_File::getNextLine($phpcsFile, (isset($nextLinePos) ? $nextLinePos : $tagPos)))
@@ -44,6 +45,7 @@ trait DisallowTagsTrait
                         || !ZichtPhpCs_File::lineContainsTokens($phpcsFile, $nextLinePos, [T_DOC_COMMENT_CLOSE_TAG, T_DOC_COMMENT_TAG])) {
                         ZichtPhpCs_File::fixRemoveWholeLine($phpcsFile, $nextLinePos);
                     }
+                    $phpcsFile->fixer->endChangeset();
                 }
             }
         }

--- a/Zicht/Sniffs/Commenting/EmptyCommentTrait.php
+++ b/Zicht/Sniffs/Commenting/EmptyCommentTrait.php
@@ -103,12 +103,16 @@ trait EmptyCommentTrait
             while ($tokens[$linePos]['line'] === $tokens[$commentStart]['line'] && T_WHITESPACE === $tokens[$linePos]['code']) {
                 $linePos--;
             }
+
+            $phpcsFile->fixer->beginChangeset();
             $linePos++;
             do {
                 $phpcsFile->fixer->replaceToken($linePos, '');
             } while ($tokens[++$linePos]['line'] <= $tokens[$commentEnd]['line']
                 && ($linePos <= $commentEnd || T_WHITESPACE === $tokens[$linePos]['code']));
+            $phpcsFile->fixer->endChangeset();
         } elseif (false !== $fixRemoveLinePos) {
+            $phpcsFile->fixer->beginChangeset();
             $commentEnd = $tokens[$commentStart]['comment_closer'];
             ZichtPhpCs_File::fixRemoveWholeLine($phpcsFile, $fixRemoveLinePos, ['start' => $commentStart, 'end' => $commentEnd]);
             while (null !== ($nextLinePos = ZichtPhpCs_File::getNextLine($phpcsFile, (isset($nextLinePos) ? $nextLinePos : $fixRemoveLinePos)))
@@ -116,6 +120,7 @@ trait EmptyCommentTrait
                 || !ZichtPhpCs_File::lineContainsTokens($phpcsFile, $nextLinePos, [T_DOC_COMMENT_CLOSE_TAG, T_DOC_COMMENT_TAG])) {
                 ZichtPhpCs_File::fixRemoveWholeLine($phpcsFile, $nextLinePos);
             }
+            $phpcsFile->fixer->endChangeset();
         }
 
         return $docBlockEmpty;

--- a/Zicht/Sniffs/Methods/FunctionOpeningBraceSniff.php
+++ b/Zicht/Sniffs/Methods/FunctionOpeningBraceSniff.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Zicht\Sniffs\Methods;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use Zicht\PhpCsFile as ZichtPhpCs_File;
+
+/**
+ * Detects if there are no empty lines between a function's opening brace and the first line of code
+ *
+ * Inspired by:
+ * @see \PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\FunctionClosingBraceSniff
+ */
+class FunctionOpeningBraceSniff implements Sniff
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function register()
+    {
+        return [
+            T_FUNCTION,
+            T_CLOSURE,
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (false === isset($tokens[$stackPtr]['scope_opener'])) {
+            // Interface or abstract method, no body, so no check
+            return;
+        }
+
+        $openBrace = $tokens[$stackPtr]['scope_opener'];
+        $bodyContent = $phpcsFile->findNext(T_WHITESPACE, ($openBrace + 1), null, true);
+        $found = ($tokens[$bodyContent]['line'] - $tokens[$openBrace]['line'] - 1);
+
+        if ($found < 0) {
+            return; // Brace isn't on a new line, so not handled by us.
+        }
+        if ($found === 0) {
+            return; // All is good.
+        }
+
+        $error = 'Function body must follow directly on the next line after the opening brace; '
+            . 'found %s blank lines between brace and body';
+        $fix = $phpcsFile->addFixableError($error, $openBrace, 'SpacingBetweenOpenAndBody', [$found]);
+
+        if (true === $fix) {
+            $phpcsFile->fixer->beginChangeset();
+            $linePos = $openBrace;
+            do {
+                $linePos = ZichtPhpCs_File::getNextLine($phpcsFile, $linePos);
+                ZichtPhpCs_File::fixRemoveWholeLine($phpcsFile, $linePos);
+            } while ($tokens[$linePos]['line'] < $tokens[$bodyContent]['line'] - 1);
+            $phpcsFile->fixer->endChangeset();
+        }
+    }
+}


### PR DESCRIPTION
Resolves #12

Adding Zicht.Methods.FunctionOpeningBrace.SpacingBetweenOpenAndBody Sniff

Also fixing some earlier Sniffs where change sets weren't used with fixing more than 1 token.