### PR TITLE
Increase max line length to 256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far 
 
+## 4.0.1 - 2019-03-29
+### Changed in Sniffs
+- Generic.Files.LineLength configuration changes: soft limit is now 256 chars
+  (warning), hard limit is now 512 charachters (error)
+
 ## 4.0.0 - 2019-02-14 💕
 ### Changed in Sniffs
 - Generic.Files.LineLength is enforced

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Roughly based on the PEAR and Zend coding standards, with inclusion of the PSR-1
 standard applies some custom rules and modifications to these standards:
 
 - There are no required tags for file and class comments.
-- Since we do no longer live in an era with fixed width consoles, the line length limit is fixed at 120, warning at
-  120, erroring at 130.
+- Since we do no longer live in an era with fixed width consoles, the line length limit is fixed at 256, warning at
+  256, erroring at 512.
 - Doc comment tags are compulsory for define() calls.
 - Global function names are `underscored_and_lowercased()`, and method names are `studlyCased`.
 - All constants, both global and class constants are `UPPERCASED_AND_UNDERSCORED`.
@@ -51,9 +51,10 @@ implement the `composer lint-no-warn` command into their Q&A jobs that should be
 ### Generic
 
 #### Generic.Files.LineLength
-This rule is configured to give warnings on lines longer than **120** characters and never give errors on line lengths
-(following [PSR-2](https://www.php-fig.org/psr/psr-2/#23-lines)). You should fix these warnings and stick to a maximum
-line length of 120 characters, but the Q&A tests should not fail on code having lines longer than 120 characters.
+This rule is configured to give warnings on lines longer than **256** characters and give errors on lines longer than
+512 characters (deliberately not following [PSR-2](https://www.php-fig.org/psr/psr-2/#23-lines)). You should fix these
+warnings and stick to a maximum line length of 256 characters, but the Q&A tests should not fail on code having lines
+longer than 256 characters and less than 512 characters.
 
 ### Zicht Sniffs
 In this section each of the rules from the Zicht set are explained.

--- a/src/Zicht/ruleset.xml
+++ b/src/Zicht/ruleset.xml
@@ -156,6 +156,14 @@
 
     <rule ref="PSR2" />
 
+    <!-- This configuration must come after including PSR2. PSR2 forces a max line length of 12 chars -->
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="256"/>
+            <property name="absoluteLineLimit" value="512"/>
+        </properties>
+    </rule>
+
     <rule ref="PSR12.Operators.OperatorSpacing.NoSpaceBefore" />
 
     <rule ref="PSR12.Operators.OperatorSpacing.NoSpaceAfter" />


### PR DESCRIPTION
Resolves #69

```
----------------------------------------------------------------------
 16 | WARNING | Line exceeds 256 characters; contains 263
    |         | characters (Generic.Files.LineLength.TooLong)
----------------------------------------------------------------------
```

```
----------------------------------------------------------------------
 16 | ERROR | Line exceeds maximum limit of 512 characters; contains
    |       | 589 characters
    |       | (Generic.Files.LineLength.MaxExceeded)
----------------------------------------------------------------------
```