### PR TITLE
Fix superfluous PHP Docblock descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added|Changed|Deprecated|Removed|Fixed|Security
-Nothing so far 
+- Fixed: Fixes superflous description for constructor when class name would contain "New"
+- Added: Minor optimization: end by return when the description would only be "{@inheritDoc}"
+- Added: Better superflous description detection by splitting up the class/method names into separate words
 
 ## 4.1.0 - 2019-06-17
 ### Changed in Sniffs


### PR DESCRIPTION
* fixing a bug: For constructor methods the word "new" would be filtered before the class name itself. If the class name would contain "New", for instance `PopularNewsFilter`, and the class name would be in the description, the result would be `"PopularsFilter"` and would not be marked as superfluous while in other cases it would
* added a minor optimization: end by return when the description would only be `"{@inheritDoc}"`
* added better filtering by splitting up the class and method names into separate words instead of whole replacements: before filtering class name `PopularNewsFilter`, now filtering `"popular"`, `"news"` and `"filter"` (also added replacements for "abstract" classes and always adding "class" as replacement also on interfaces and traits)