### PR TITLE
Loosen constant naming sniff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added|Changed|Deprecated|Removed|Fixed|Security
-Nothing so far
+- Loosen the Zicht.NamingConventions.Constants.InvalidName sniff
 
 ## 3.5.0 - 2019-02-12
 ### Added

--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ Detects if there are no empty lines between a function's opening brace and the f
 This sniff requires class names to be `CamelCased`.
 
 #### Zicht.NamingConventions.Constants
-This sniff requires a constant name to start with letters `A-Z` followed by `A-Z`, `_` or `0-9`.
+This sniff requires a constant name to be `UPPERCASE` (no lower case characters allowed) and no characters other than
+A-Z, 0-9 and underscore.
  
 #### Zicht.NamingConventions.Functions
 This sniff defines the naming conventions.

--- a/Zicht/Sniffs/NamingConventions/ConstantsSniff.php
+++ b/Zicht/Sniffs/NamingConventions/ConstantsSniff.php
@@ -46,9 +46,16 @@ class ConstantsSniff implements Sniff
             $name = substr($name, 1, -1);
         }
 
-        if (!preg_match('/^[A-Z][A-Z_]*[0-9]*$/', $name)) {
-            $phpcsFile->addWarning(
-                'Constant "%s" should be UPPERCASED_AND_UNDERSCORED',
+        /**
+         * PHP language natively allows ^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$
+         * For example \x80 is € and \x85 is …, so we don't want \x80-\xff
+         * and starting with a _ is also not really conventional
+         * @see https://www.php.net/manual/en/language.constants.php
+         */
+        if (!preg_match('/^[A-Z][A-Z0-9_]*$/', $name)) {
+            $phpcsFile->addError(
+                'Constant "%s" should be UPPERCASED_AND_UNDERSCORED, should start wit a letter '
+                . 'and cannot contain characters other than A-Z, 0-9 and underscore',
                 $stackPtr,
                 'InvalidName',
                 [$name]


### PR DESCRIPTION
I had these constants in a project, which were not allowed:

```php
    const HEIGHT_100P = '100%';
    const HEIGHT_1000PX = '1000px';
```
So I wanted to loosen this restriction. I don't see why we should only allow numbers to be at the end of the constant.

* [x] Please check and discuss remark about `preg_match('/[\x80-\xff]/', $name)`

Targeting the release/3.x branch to fix this in a project still running 3.5.0. Will merge it through into the release/4.x branch