### PR TITLE
Changed property comment sniff to allow ampersand `&` besides pipe `|` in var type lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 - Nothing so far
 
+## 4.1.6 - 2021-06-08
+### Fixed
+- Changed property comment sniff to allow ampersand `&` besides pipe `|` in var type lists
+
 ## 4.1.5 - 2021-03-02
 ### Fixed
 - String offset access syntax with curly braces is deprecated in PHP 7.4

--- a/src/Zicht/Sniffs/Commenting/PropertyCommentSniff.php
+++ b/src/Zicht/Sniffs/Commenting/PropertyCommentSniff.php
@@ -262,7 +262,7 @@ class PropertyCommentSniff extends AbstractVariableSniff
         $varPattern = sprintf('(\\\\?%s(?:\\\\%1$s)*)', $classPattern);
         $arrayPostfix = '(?:\\[\\])+|<(?:(?R), ?)?(?R)>';
         $typePattern = sprintf('(%1$s(%2$s)?|\\(((?R)(?:\\|(?R))+)\\)(%2$s))', $varPattern, $arrayPostfix);
-        $fullPattern = $typePattern . '(?:\\|' . $typePattern . ')*';
+        $fullPattern = $typePattern . '(?:[\\|&]' . $typePattern . ')*';
 
         $varTagContentPattern = str_replace('(?R)', '(?2)', '/^(' . $fullPattern . ')(?:[ \t]*$|[ \t]+(?P<d>.+)$)/');
         if (0 === (int)preg_match($varTagContentPattern, $descLine1, $match)) {


### PR DESCRIPTION
Om iets als onderstaand toe te staan:

```php
    /** @var Collection&Selectable */
    private Collection $someCollectionThatShouldAlsoBeSelectable;
```

De voorheen veel gebruikte `|` is hier dan eigenlijk niet correct, omdat je dan zegt: het kan een `Collection` zijn OF `Selectable` (of beide), maar er is dus geen zekerheid dat je de methods van `Selectable` kunt aanroepen.
```php
    /** @var Collection|Selectable */
    private Collection $someCollectionThatShouldAlsoBeSelectable;
```