### PR TITLE
add missing 'magic' methods __isset and __unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 - Nothing so far
 
+## 4.1.7 - 2021-09-07
+### Added
+- Added missing 'magic' methods __isset and __unset to allow list
+
 ## 4.1.6 - 2021-06-08
 ### Fixed
 - Changed property comment sniff to allow ampersand `&` besides pipe `|` in var type lists

--- a/src/Zicht/Sniffs/NamingConventions/FunctionsSniff.php
+++ b/src/Zicht/Sniffs/NamingConventions/FunctionsSniff.php
@@ -57,8 +57,8 @@ class FunctionsSniff implements Sniff
                         substr($functionName, 2),
                         [
                             'construct', 'get', 'set', 'call', 'callStatic', 'invoke',
-			    'destruct', 'toString', 'clone', 'invoke', 'invokeStatic',
-			    'isset', 'unset',
+                            'destruct', 'toString', 'clone', 'invoke', 'invokeStatic',
+                            'isset', 'unset',
                         ]
                     )
                 ) {

--- a/src/Zicht/Sniffs/NamingConventions/FunctionsSniff.php
+++ b/src/Zicht/Sniffs/NamingConventions/FunctionsSniff.php
@@ -57,7 +57,8 @@ class FunctionsSniff implements Sniff
                         substr($functionName, 2),
                         [
                             'construct', 'get', 'set', 'call', 'callStatic', 'invoke',
-                            'destruct', 'toString', 'clone', 'invoke', 'invokeStatic',
+			    'destruct', 'toString', 'clone', 'invoke', 'invokeStatic',
+			    'isset', 'unset',
                         ]
                     )
                 ) {


### PR DESCRIPTION
`__isset` is nodig als je `__get` wilt gebruiken in Twig templates. Deze PR zorgt dat phpcs niet meer klaagt als je de `__isset()` implementeert.

Voor de volledigheid heb ik 'unset' ook toegevoegd.